### PR TITLE
Allow parametrizing log function in ConsoleLogQueryRunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -2264,6 +2264,8 @@ async function main() {
 
 A query runner that write all the queries to the standard output using `console.log` and delegate the execution of the queries to the query runner received as argument in the constructor.
 
+If you don't want to use `console.log`, you can also pass in your own logging function as second constructor argument.
+
 **Supported databases**: mariaDB, mySql, oracle, postgreSql, sqlite, sqlServer
 
 ```ts

--- a/src/queryRunners/ConsoleLogQueryRunner.ts
+++ b/src/queryRunners/ConsoleLogQueryRunner.ts
@@ -1,69 +1,80 @@
 import type { QueryRunner } from "./QueryRunner"
 import { ChainedQueryRunner } from "./ChainedQueryRunner"
 
+/**
+ * Log every query with `console.log` or a user-provided logging function,
+ * then pass it on to the next query runner.
+ */
 export class ConsoleLogQueryRunner<T extends QueryRunner> extends ChainedQueryRunner<T> {
-    constructor(queryRunner: T) {
+    private log: (message?: any, ...optionalParams: any[]) => void;
+
+    constructor(queryRunner: T, logFunction?: (message?: any, ...optionalParams: any[]) => void) {
         super(queryRunner)
+        if (logFunction !== undefined) {
+            this.log = logFunction;
+        } else {
+            this.log = console.log;
+        }
     }
 
     executeSelectOneRow(query: string, params: any[] = []): Promise<any> {
-        console.log('executeSelectOneRow:', query, params)
+        this.log('executeSelectOneRow:', query, params)
         return this.queryRunner.executeSelectOneRow(query, params)
     }
     executeSelectManyRows(query: string, params: any[] = []): Promise<any[]> {
-        console.log('executeSelectManyRows:', query, params)
+        this.log('executeSelectManyRows:', query, params)
         return this.queryRunner.executeSelectManyRows(query, params)
     }
     executeSelectOneColumnOneRow(query: string, params: any[] = []): Promise<any> {
-        console.log('executeSelectOneColumnOneRow:', query, params)
+        this.log('executeSelectOneColumnOneRow:', query, params)
         return this.queryRunner.executeSelectOneColumnOneRow(query, params)
     }
     executeSelectOneColumnManyRows(query: string, params: any[] = []): Promise<any[]> {
-        console.log('executeSelectOneColumnManyRows:', query, params)
+        this.log('executeSelectOneColumnManyRows:', query, params)
         return this.queryRunner.executeSelectOneColumnManyRows(query, params)
     }
     executeInsert(query: string, params: any[] = []): Promise<number> {
-        console.log('executeInsert:', query, params)
+        this.log('executeInsert:', query, params)
         return this.queryRunner.executeInsert(query, params)
     }
     executeInsertReturningLastInsertedId(query: string, params: any[] = []): Promise<any> {
-        console.log('executeInsertReturningLastInsertedId:', query, params)
+        this.log('executeInsertReturningLastInsertedId:', query, params)
         return this.queryRunner.executeInsertReturningLastInsertedId(query, params)
     }
     executeInsertReturningMultipleLastInsertedId(query: string, params: any[] = []): Promise<any> {
-        console.log('executeInsertReturningMultipleLastInsertedId:', query, params)
+        this.log('executeInsertReturningMultipleLastInsertedId:', query, params)
         return this.queryRunner.executeInsertReturningMultipleLastInsertedId(query, params)
     }
     executeUpdate(query: string, params: any[] = []): Promise<number> {
-        console.log('executeUpdate:', query, params)
+        this.log('executeUpdate:', query, params)
         return this.queryRunner.executeUpdate(query, params)
     }
     executeDelete(query: string, params: any[] = []): Promise<number> {
-        console.log('executeDelete:', query, params)
+        this.log('executeDelete:', query, params)
         return this.queryRunner.executeDelete(query, params)
     }
     executeProcedure(query: string, params: any[] = []): Promise<void> {
-        console.log('executeProcedure:', query, params)
+        this.log('executeProcedure:', query, params)
         return this.queryRunner.executeProcedure(query, params)
     }
     executeFunction(query: string, params: any[] = []): Promise<any> {
-        console.log('executeFunction:', query, params)
+        this.log('executeFunction:', query, params)
         return this.queryRunner.executeFunction(query, params)
     }
     executeBeginTransaction(): Promise<void> {
-        console.log('executeBeginTransaction:', undefined, undefined)
+        this.log('executeBeginTransaction:', undefined, undefined)
         return this.queryRunner.executeBeginTransaction()
     }
     executeCommit(): Promise<void> {
-        console.log('executeCommit:', undefined, undefined)
+        this.log('executeCommit:', undefined, undefined)
         return this.queryRunner.executeCommit()
     }
     executeRollback(): Promise<void> {
-        console.log('executeRollback:', undefined, undefined)
+        this.log('executeRollback:', undefined, undefined)
         return this.queryRunner.executeRollback()
     }
     executeDatabaseSchemaModification(query: string, params: any[] = []): Promise<void> {
-        console.log('executeDatabaseSchemaModification:', query, params)
+        this.log('executeDatabaseSchemaModification:', query, params)
         return this.queryRunner.executeDatabaseSchemaModification(query, params)
     }
 }


### PR DESCRIPTION
For certain use cases, it's useful if the logging function can be parametrized without having to write an entire new query runner.

Function signature is copied from `console.log`, so any compatible function should work, for example:

```typescript
(message, ...params) => { console.debug('[sql] ' + message, ...params); }
```