### PR TITLE
Fix type-errors for symbol-keyed phantom properties

### DIFF
--- a/src/Table.ts
+++ b/src/Table.ts
@@ -11,10 +11,10 @@ import { RawFragment } from "./utils/RawFragment"
 import type { TABLE } from "./typeMarks/TABLE"
 
 class TableOf<REF extends TABLE<AnyDB, any>> implements ITable<REF> {
-    [database]: REF[typeof database]
-    [type]: 'table'
-    [viewName]: REF[typeof tableName]
-    [tableOrViewRef]: REF
+    [database]!: REF[typeof database]
+    [type]!: 'table'
+    [viewName]!: REF[typeof tableName]
+    [tableOrViewRef]!: REF
     /* implements __ITableOrViewPrivate as private members*/
     // @ts-ignore
     private __name: string

--- a/src/View.ts
+++ b/src/View.ts
@@ -11,10 +11,10 @@ import { RawFragment } from "./utils/RawFragment"
 import type { VIEW } from "./typeMarks/VIEW"
 
 class ViewOf<REF extends VIEW<AnyDB, any>> implements IView<REF> {
-    [database]: REF[typeof database]
-    [type]: 'view'
-    [viewName]: REF[typeof viewName]
-    [tableOrViewRef]: REF
+    [database]!: REF[typeof database]
+    [type]!: 'view'
+    [viewName]!: REF[typeof viewName]
+    [tableOrViewRef]!: REF
     /* implements __ITableOrViewPrivate as private members*/
     // @ts-ignore
     private __name: string

--- a/src/connections/AbstractConnection.ts
+++ b/src/connections/AbstractConnection.ts
@@ -32,9 +32,9 @@ import { CustomizedTableOrView } from "../utils/tableOrViewUtils"
 import { InnerResultObjectValuesForAggregatedArray } from "../utils/resultUtils"
 
 export abstract class AbstractConnection<DB extends AnyDB> implements IConnection<DB> {
-    [database]: DB
-    [type]: 'Connection'
-    
+    [database]!: DB
+    [type]!: 'Connection'
+
     protected __sqlBuilder: SqlBuilder
     protected allowEmptyString: boolean = false
     protected insesitiveCollation?: string
@@ -62,7 +62,7 @@ export abstract class AbstractConnection<DB extends AnyDB> implements IConnectio
             }
             this.onCommitStack.push(this.onCommit)
             this.onCommit = undefined
-            
+
             if (!this.onRollbackStack) {
                 this.onRollbackStack = []
             }
@@ -163,7 +163,7 @@ export abstract class AbstractConnection<DB extends AnyDB> implements IConnectio
                 this.popTransactionStack()
                 return callDeferredFunctions('after next commit', onCommit, undefined, source)
             }, (e) => {
-                // Transaction only closed when commit successful, in case of error there is still an open transaction 
+                // Transaction only closed when commit successful, in case of error there is still an open transaction
                 // No rollback yet, then no executeAfterNextRollback will be executed
                 throw attachSource(new ChainedError(e), source)
             })
@@ -202,7 +202,7 @@ export abstract class AbstractConnection<DB extends AnyDB> implements IConnectio
         return new UpdateQueryBuilder(this.__sqlBuilder, table, true) as any
     }
     deleteFrom<TABLE extends ITableOf<DB, any>>(table: TABLE): DeleteExpression<TABLE, TABLE> {
-        return new DeleteQueryBuilder(this.__sqlBuilder, table, false) as any 
+        return new DeleteQueryBuilder(this.__sqlBuilder, table, false) as any
     }
     deleteAllowingNoWhereFrom<TABLE extends ITableOf<DB, any>>(table: TABLE): DeleteExpressionAllowingNoWhere<TABLE, TABLE> {
         return new DeleteQueryBuilder(this.__sqlBuilder, table, true) as any

--- a/src/expressions/Default.ts
+++ b/src/expressions/Default.ts
@@ -6,7 +6,7 @@ export interface Default {
 }
 
 export class DefaultImpl implements Default, ToSql {
-    [type]: 'default'
+    [type]!: 'default'
     __toSql(SqlBuilder: SqlBuilder, params: any[]): string {
         return SqlBuilder._default(params)
     }

--- a/src/expressions/values.ts
+++ b/src/expressions/values.ts
@@ -32,7 +32,7 @@ export type OptionalTypeRequiredOrAny<OPTIONAL_TYPE extends OptionalType> =
     OPTIONAL_TYPE extends 'any' ? any :
     OPTIONAL_TYPE extends 'required' ? 'required' : any
 
-type OptionalValueType<OPTIONAL_TYPE extends OptionalType> = 
+type OptionalValueType<OPTIONAL_TYPE extends OptionalType> =
     OPTIONAL_TYPE extends 'optional' ? null | undefined : never
 
 export type ValueSourceValueType<T> = T extends IValueSource<any, infer TYPE, any, infer OPTIONAL_TYPE> ? TYPE | OptionalValueType<OPTIONAL_TYPE> : never
@@ -1597,7 +1597,7 @@ export interface TypeSafeStringValueSource<TABLE_OR_VIEW extends TableOrViewRef<
     substr<VALUE2 extends IIntValueSource<TableOrViewRef<this[typeof database]>, any>>(start: int, count: VALUE2): TypeSafeStringValueSource<TABLE_OR_VIEW | VALUE2[typeof tableOrView], MergeOptional<OPTIONAL_TYPE, VALUE2[typeof optionalType]>>
     substr<VALUE extends IIntValueSource<TableOrViewRef<this[typeof database]>, any>>(start: VALUE, count: int): TypeSafeStringValueSource<TABLE_OR_VIEW | VALUE[typeof tableOrView], MergeOptional<OPTIONAL_TYPE, VALUE[typeof optionalType]>>
     substr<VALUE extends IIntValueSource<TableOrViewRef<this[typeof database]>, any>, VALUE2 extends IIntValueSource<TableOrViewRef<this[typeof database]>, any>>(start: VALUE, count: VALUE2): TypeSafeStringValueSource<TABLE_OR_VIEW | VALUE[typeof tableOrView] | VALUE2[typeof tableOrView], MergeOptional<MergeOptional<OPTIONAL_TYPE, VALUE[typeof optionalType]>, VALUE2[typeof optionalType]>>
-    substring(start: int, end: int): TypeSafeStringValueSource<TABLE_OR_VIEW, OPTIONAL_TYPE>    
+    substring(start: int, end: int): TypeSafeStringValueSource<TABLE_OR_VIEW, OPTIONAL_TYPE>
     substring<VALUE2 extends IIntValueSource<TableOrViewRef<this[typeof database]>, any>>(start: int, end: VALUE2): TypeSafeStringValueSource<TABLE_OR_VIEW | VALUE2[typeof tableOrView], MergeOptional<OPTIONAL_TYPE, VALUE2[typeof optionalType]>>
     substring<VALUE extends IIntValueSource<TableOrViewRef<this[typeof database]>, any>>(start: VALUE, end: int): TypeSafeStringValueSource<TABLE_OR_VIEW | VALUE[typeof tableOrView], MergeOptional<OPTIONAL_TYPE, VALUE[typeof optionalType]>>
     substring<VALUE extends IIntValueSource<TableOrViewRef<this[typeof database]>, any>, VALUE2 extends IIntValueSource<TableOrViewRef<this[typeof database]>, any>>(start: VALUE, end: VALUE2): TypeSafeStringValueSource<TABLE_OR_VIEW | VALUE[typeof tableOrView] | VALUE2[typeof tableOrView], MergeOptional<MergeOptional<OPTIONAL_TYPE, VALUE[typeof optionalType]>, VALUE2[typeof optionalType]>>
@@ -1935,8 +1935,8 @@ export class Argument<T extends ArgumentType, OPTIONAL_TYPE extends ArgumentOpti
     readonly optionalType: OPTIONAL_TYPE
     readonly mode: MODE
     readonly adapter?: TypeAdapter
-    [valueType]: TYPE
-    [valueSourceTypeName]: TYPE_NAME
+    [valueType]!: TYPE
+    [valueSourceTypeName]!: TYPE_NAME
 
     constructor (argumentType: T, typeName: string, optionalType: OPTIONAL_TYPE, mode: MODE, adapter?: TypeAdapter) {
         this.type = argumentType

--- a/src/internal/ColumnImpl.ts
+++ b/src/internal/ColumnImpl.ts
@@ -9,7 +9,7 @@ import { ProxyTypeAdapter } from "./ProxyTypeAdapter"
 import { isColumnObject, type } from "../utils/symbols"
 
 export class ColumnImpl extends ValueSourceImpl implements Column, __ColumnPrivate, ToSql {
-    [type]: 'column'
+    [type]!: 'column'
     [isColumnObject]: true = true
     __name: string
     __tableOrView: ITableOrView<any>
@@ -133,7 +133,7 @@ export function createColumnsFrom(columns: QueryColumns, target: QueryColumns, t
 
 export function createColumnsFromInnerObject(columns: QueryColumns, target: QueryColumns, table: ITableOrView<any>, prefix: string) {
     const rule = getInnerObjetRuleToApply(columns)
-    
+
     for (const property in columns) {
         const column = columns[property]!
         if (isValueSource(column)) {
@@ -197,7 +197,7 @@ export function getInnerObjetRuleToApply(columns: QueryColumns): 1 | 2 | 3 | 4 {
             const optionalType = columnPrivate.__optionalType
 
             switch (optionalType) {
-            case 'requiredInOptionalObject': 
+            case 'requiredInOptionalObject':
                 return 1 // Rule 1, there is requiredInOptionalObject
             case 'required':
                 containsRequired = true

--- a/src/internal/RawFragmentImpl.ts
+++ b/src/internal/RawFragmentImpl.ts
@@ -6,9 +6,9 @@ import { RawFragment } from "../utils/RawFragment"
 import { database, rawFragment } from "../utils/symbols"
 
 export class RawFragmentImpl implements RawFragment<any>, HasAddWiths, ToSql {
-    [rawFragment]: "rawFragment"
+    [rawFragment]!: "rawFragment"
     [database]: any
-    
+
     __template: TemplateStringsArray
     __params: Array<AnyValueSource | IExecutableSelectQuery<any, any, any, any> | IExecutableInsertQuery<any, any> | IExecutableUpdateQuery<any, any> | IExecutableDeleteQuery<any, any>>
 

--- a/src/internal/ValueSourceImpl.ts
+++ b/src/internal/ValueSourceImpl.ts
@@ -9,33 +9,33 @@ import { ProxyTypeAdapter } from "./ProxyTypeAdapter"
 import { Column } from "../utils/Column"
 
 export abstract class ValueSourceImpl implements IValueSource<any, any, any, any>, NullableValueSource<any, any, any, any>, BooleanValueSource<any, any>, IntValueSource<any, any>, StringIntValueSource<any, any>, DoubleValueSource<any, any>, StringDoubleValueSource<any, any>, NumberValueSource<any, any>, StringNumberValueSource<any, any>, BigintValueSource<any, any>, TypeSafeBigintValueSource<any, any>, StringValueSource<any, any>, TypeSafeStringValueSource<any, any>, LocalDateValueSource<any, any>, LocalTimeValueSource<any, any>, LocalDateTimeValueSource<any, any>, DateValueSource<any, any>, TimeValueSource<any, any>, DateTimeValueSource<any, any>, IfValueSource<any, any>, AlwaysIfValueSource<any, any>, IAnyBooleanValueSource<any, any>, IAggregatedArrayValueSource<any, any, any>, AggregatedArrayValueSource<any, any, any>, UuidValueSource<any, any>, TypeSafeUuidValueSource<any, any>, ToSql, __ValueSourcePrivate {
-    [valueSourceType]: 'ValueSource'
-    [nullableValueSourceType]: 'NullableValueSource'
-    [equalableValueSourceType]: 'EqualableValueSource'
-    [comparableValueSourceType]: 'ComparableValueSource'
-    [booleanValueSourceType]: 'BooleanValueSource'
-    [ifValueSourceType]: 'IfValueSource'
-    [numberValueSourceType]: 'NumberValueSource'
-    [stringNumberValueSourceType]: 'StringNumberValueSource'
-    [intValueSourceType]: 'IntValueSource'
-    [doubleValueSourceType]: 'DoubleValueSource'
-    [bigintValueSourceType]: 'BigintValueSource'
-    [typeSafeBigintValueSourceType]: 'TypeSafeBigintValueSource'
-    [stringIntValueSourceType]: 'StringIntValueSource'
-    [stringDoubleValueSourceType]: 'StringDoubleValueSource'
-    [stringValueSourceType]: 'StringValueSource'
-    [typeSafeStringValueSourceType]: 'TypeSafeStringValueSource'
-    [dateValueSourceType]: 'DateValueSource'
-    [timeValueSourceType]: 'TimeValueSource'
-    [dateTimeValueSourceType]: 'DateTimeValueSource'
-    [localDateValueSourceType]: 'LocalDateValueSource'
-    [localTimeValueSourceType]: 'LocalTimeValueSource'
-    [localDateTimeValueSourceType]: 'LocalDateTimeValueSource'
-    [anyBooleanValueSourceType]: 'AnyBooleanValueSource'
-    [aggregatedArrayValueSourceType]: 'AggregatedArrayValueSource'
-    [uuidValueSourceType]: 'UuidValueSource'
-    [typeSafeUuidValueSourceType]: 'TypeSafeUuidValueSource'
-    [valueSourceTypeName]: any
+    [valueSourceType]!: 'ValueSource'
+    [nullableValueSourceType]!: 'NullableValueSource'
+    [equalableValueSourceType]!: 'EqualableValueSource'
+    [comparableValueSourceType]!: 'ComparableValueSource'
+    [booleanValueSourceType]!: 'BooleanValueSource'
+    [ifValueSourceType]!: 'IfValueSource'
+    [numberValueSourceType]!: 'NumberValueSource'
+    [stringNumberValueSourceType]!: 'StringNumberValueSource'
+    [intValueSourceType]!: 'IntValueSource'
+    [doubleValueSourceType]!: 'DoubleValueSource'
+    [bigintValueSourceType]!: 'BigintValueSource'
+    [typeSafeBigintValueSourceType]!: 'TypeSafeBigintValueSource'
+    [stringIntValueSourceType]!: 'StringIntValueSource'
+    [stringDoubleValueSourceType]!: 'StringDoubleValueSource'
+    [stringValueSourceType]!: 'StringValueSource'
+    [typeSafeStringValueSourceType]!: 'TypeSafeStringValueSource'
+    [dateValueSourceType]!: 'DateValueSource'
+    [timeValueSourceType]!: 'TimeValueSource'
+    [dateTimeValueSourceType]!: 'DateTimeValueSource'
+    [localDateValueSourceType]!: 'LocalDateValueSource'
+    [localTimeValueSourceType]!: 'LocalTimeValueSource'
+    [localDateTimeValueSourceType]!: 'LocalDateTimeValueSource'
+    [anyBooleanValueSourceType]!: 'AnyBooleanValueSource'
+    [aggregatedArrayValueSourceType]!: 'AggregatedArrayValueSource'
+    [uuidValueSourceType]!: 'UuidValueSource'
+    [typeSafeUuidValueSourceType]!: 'TypeSafeUuidValueSource'
+    [valueSourceTypeName]!: any
 
     [database]: any
     [tableOrView]: any
@@ -422,7 +422,7 @@ export abstract class ValueSourceImpl implements IValueSource<any, any, any, any
         } else if (this.__valueType === 'stringDouble') {
             // Unsafe cast, it happens when TypeSafe is not in use, we round the value
             return new SqlOperation0ValueSource('_round', this, 'int', this.__optionalType, this.__typeAdapter)
-        } 
+        }
         return new NoopValueSource(this, 'int', this.__optionalType, this.__typeAdapter)
     }
     asStringInt(): any {
@@ -432,7 +432,7 @@ export abstract class ValueSourceImpl implements IValueSource<any, any, any, any
         } else if (this.__valueType === 'stringDouble') {
             // Unsafe cast, it happens when TypeSafe is not in use, we round the value
             return new SqlOperation0ValueSource('_round', this, 'stringInt', this.__optionalType, this.__typeAdapter)
-        } 
+        }
         return new NoopValueSource(this, 'stringInt', this.__optionalType, this.__typeAdapter)
     }
     asBigint(): any {
@@ -442,7 +442,7 @@ export abstract class ValueSourceImpl implements IValueSource<any, any, any, any
         } else if (this.__valueType === 'stringDouble') {
             // Unsafe cast, it happens when TypeSafe is not in use, we round the value
             return new SqlOperation0ValueSource('_round', this, 'bigint', this.__optionalType, this.__typeAdapter)
-        } 
+        }
         return new NoopValueSource(this, 'bigint', this.__optionalType, this.__typeAdapter)
     }
     abs(): any {
@@ -1258,7 +1258,7 @@ export class SqlOperationInValueSourceIfValueOrNoop extends ValueSourceImpl impl
 }
 
 export class SqlOperationValueSourceIfValueAlwaysNoop extends ValueSourceImpl {
-    
+
     constructor() {
         super('', 'required', undefined)
     }
@@ -1679,7 +1679,7 @@ export class TableOrViewRawFragmentValueSource implements ValueSource<any, any, 
     [valueType_]: any
     [optionalType_]: any
     [optionalType]: any
-    [valueSourceType]: "ValueSource"
+    [valueSourceType]!: "ValueSource"
     [database]: any
     [valueSourceTypeName]: any
 
@@ -1814,10 +1814,10 @@ export class AggregateValueAsArrayValueSource implements ValueSource<any, any, a
     [valueType_]: any
     [optionalType_]: any
     [optionalType]: any
-    [valueSourceType]: "ValueSource"
+    [valueSourceType]!: "ValueSource"
     [database]: any
     [valueSourceTypeName]: any
-    [aggregatedArrayValueSourceType]: 'AggregatedArrayValueSource'
+    [aggregatedArrayValueSourceType]!: 'AggregatedArrayValueSource'
 
     [isValueSourceObject]: true = true
     __valueType: string = 'aggregatedArray'

--- a/src/internal/WithViewImpl.ts
+++ b/src/internal/WithViewImpl.ts
@@ -9,9 +9,9 @@ import { RawFragment } from "../utils/RawFragment"
 import { Column } from "../utils/Column"
 
 export class WithViewImpl<NAME extends string, REF extends WITH_VIEW<AnyDB, NAME>> implements IWithView<REF>, WithData, __ITableOrViewPrivate {
-    [database]: REF[typeof database]
-    [type]: 'with'
-    [tableOrViewRef]: REF
+    [database]!: REF[typeof database]
+    [type]!: 'with'
+    [tableOrViewRef]!: REF
     /* implements __ITableOrViewPrivate as private members*/
     __name: string
     // @ts-ignore
@@ -35,13 +35,13 @@ export class WithViewImpl<NAME extends string, REF extends WITH_VIEW<AnyDB, NAME
         if (selectData.__subSelectUsing) {
             this.__hasExternalDependencies = selectData.__subSelectUsing.length > 0
         }
-        
+
         const columns = selectData.__columns
         createColumnsFrom(columns, this as any, this)
     }
-    [type]: "with"
-    [tableOrViewRef]: REF
-    [database]: REF[typeof database]
+    [type]!: "with"
+    [tableOrViewRef]!: REF
+    [database]!: REF[typeof database]
 
     as<ALIAS extends string>(as: ALIAS): AliasedTableOrView<this, ALIAS> {
         const result = new WithViewImpl(this.__name, this.__selectData)

--- a/src/utils/RawFragment.ts
+++ b/src/utils/RawFragment.ts
@@ -2,6 +2,6 @@ import { AnyDB } from "../databases"
 import { database, rawFragment } from "./symbols"
 
 export class RawFragment<DB extends AnyDB> {
-    [rawFragment]: 'rawFragment'
-    [database]: DB
+    [rawFragment]!: 'rawFragment'
+    [database]!: DB
 }


### PR DESCRIPTION
In master running `npm run build` results in a bunch of build errors ([attached](https://github.com/juanluispaz/ts-sql-query/files/8932776/build-error.log))

It seems like that we have a bunch of symbol-keyed properties that are used primarily for propagating types and are not actually present/used at runtime. 


This usage is a bit strange for me, but it is easy to suppress these errors by using `!` for these properties to prevent typescript from complaining about them. 