### PR TITLE
Fix boolean value binding for Oracle

### DIFF
--- a/src/connections/AbstractOracleConnection.ts
+++ b/src/connections/AbstractOracleConnection.ts
@@ -14,11 +14,8 @@ export abstract class AbstractOracleConnection<DB extends Oracle & (TypeUnsafeDB
 
     protected transformValueToDB(value: unknown, type: string): unknown {
         if (type === 'boolean' && typeof value === 'boolean') {
-            if (value) {
-                return 0
-            } else {
-                return 1
-            }
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#number_coercion
+            return Number(value);
         }
         return super.transformValueToDB(value, type)
     }


### PR DESCRIPTION
Not sure if it's the way you prefer. But `return value ? 1 : 0;` still has a chance to make a human mistake, while `Number(value)` is well-defined and looks perfect for this case.

resolve #87 
