### PR TITLE
LoggingQueryRunner: Use performance.now() in non-Node environments

### DIFF
--- a/docs/query-runners/general-purpose-query-runners.md
+++ b/docs/query-runners/general-purpose-query-runners.md
@@ -39,7 +39,7 @@ The `` receives a secondary optional argument with the folloging definition:
 ```ts
 interface ConsoleLogQueryRunnerOpts {
     timeGranularity?: 'ms' | 'us' | 'ns' // Granularity of time and duration logged, default 'ms'
-    logTimestamps?: boolean // Include the time value of process.hrtime.bigint() when the log happened, default false
+    logTimestamps?: boolean // Include the time value when the log happened in naonseconds since an arbitrary starting point, default false
     logDurations?: boolean // Include the duration of the query execution, default false
     logResults?: boolean // Include the result object in the log, default false
     paramsAsObject?: boolean // Write in the log the query, params, result and error wrapped in an object, default false
@@ -162,8 +162,8 @@ type QueryType = 'selectOneRow' | 'selectManyRows' | 'selectOneColumnOneRow' | '
 - **`params: any[]`**: parameters received by the query.
 - **`result: any`**: (only in `onQueryResult`) result of the execution of the query.
 - **`error: any`**: (only in `onQueryError`) error that happens executiong the query.
-- **`startedAt`**: value of `process.hrtime.bigint()` before the query execution.
-- **`endedAt`**: (only in `onQueryResult` or  `onQueryError`) value of `process.hrtime.bigint()` after the query execution.
+- **`startedAt`**: elapsed time value in naonoseconds before the query execution.
+- **`endedAt`**: (only in `onQueryResult` or  `onQueryError`) elapsed time value in naonoseconds after the query execution.
 
 **Note**:
 - `onQuery`, `onQueryResult` and `onQueryError` are optionals; you can defined only the method that you needs.

--- a/src/queryRunners/LoggingQueryRunner.ts
+++ b/src/queryRunners/LoggingQueryRunner.ts
@@ -7,6 +7,16 @@ export interface QueryLogger {
     onQueryError?: (queryType: QueryType, query: string, params: any[], error: any, timestamps: { startedAt: bigint, endedAt: bigint }) => void;
 }
 
+function now(): bigint {
+    if (typeof process !== 'undefined') {
+        // NodeJS process module available
+        return process.hrtime.bigint();
+    } else {
+        // NodeJS process module not available
+        return BigInt(Math.floor(performance.now() * 1000 * 1000));
+    }
+}
+
 export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunner<T> {
     readonly logger: QueryLogger
 
@@ -17,7 +27,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
 
     executeSelectOneRow(query: string, params: any[] = []): Promise<any> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('selectOneRow', query, params, { startedAt })
         }
@@ -25,12 +35,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('selectOneRow', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('selectOneRow', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('selectOneRow', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('selectOneRow', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -39,7 +49,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeSelectManyRows(query: string, params: any[] = []): Promise<any[]> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('selectManyRows', query, params, { startedAt })
         }
@@ -47,12 +57,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('selectManyRows', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('selectManyRows', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('selectManyRows', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('selectManyRows', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -61,7 +71,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeSelectOneColumnOneRow(query: string, params: any[] = []): Promise<any> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('selectOneColumnOneRow', query, params, { startedAt })
         }
@@ -69,12 +79,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('selectOneColumnOneRow', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('selectOneColumnOneRow', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('selectOneColumnOneRow', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('selectOneColumnOneRow', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -83,7 +93,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeSelectOneColumnManyRows(query: string, params: any[] = []): Promise<any[]> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('selectOneColumnManyRows', query, params, { startedAt })
         }
@@ -91,12 +101,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('selectOneColumnManyRows', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('selectOneColumnManyRows', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('selectOneColumnManyRows', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('selectOneColumnManyRows', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -105,7 +115,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeInsert(query: string, params: any[] = []): Promise<number> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('insert', query, params, { startedAt })
         }
@@ -113,12 +123,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('insert', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('insert', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('insert', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('insert', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -127,7 +137,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeInsertReturningLastInsertedId(query: string, params: any[] = []): Promise<any> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('insertReturningLastInsertedId', query, params, { startedAt })
         }
@@ -135,12 +145,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('insertReturningLastInsertedId', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('insertReturningLastInsertedId', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('insertReturningLastInsertedId', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('insertReturningLastInsertedId', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -149,7 +159,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeInsertReturningMultipleLastInsertedId(query: string, params: any[] = []): Promise<any> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('insertReturningMultipleLastInsertedId', query, params, { startedAt })
         }
@@ -157,12 +167,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('insertReturningMultipleLastInsertedId', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('insertReturningMultipleLastInsertedId', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('insertReturningMultipleLastInsertedId', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('insertReturningMultipleLastInsertedId', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -171,7 +181,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeInsertReturningOneRow(query: string, params: any[] = []): Promise<any> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('insertReturningOneRow', query, params, { startedAt })
         }
@@ -179,12 +189,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('insertReturningOneRow', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('insertReturningOneRow', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('insertReturningOneRow', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('insertReturningOneRow', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -193,7 +203,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeInsertReturningManyRows(query: string, params: any[] = []): Promise<any[]> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('insertReturningManyRows', query, params, { startedAt })
         }
@@ -201,12 +211,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('insertReturningManyRows', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('insertReturningManyRows', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('insertReturningManyRows', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('insertReturningManyRows', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -215,7 +225,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeInsertReturningOneColumnOneRow(query: string, params: any[] = []): Promise<any> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('insertReturningOneColumnOneRow', query, params, { startedAt })
         }
@@ -223,12 +233,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('insertReturningOneColumnOneRow', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('insertReturningOneColumnOneRow', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('insertReturningOneColumnOneRow', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('insertReturningOneColumnOneRow', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -237,7 +247,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeInsertReturningOneColumnManyRows(query: string, params: any[] = []): Promise<any[]> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('insertReturningOneColumnManyRows', query, params, { startedAt })
         }
@@ -245,12 +255,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('insertReturningOneColumnManyRows', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('insertReturningOneColumnManyRows', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('insertReturningOneColumnManyRows', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('insertReturningOneColumnManyRows', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -259,7 +269,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeUpdate(query: string, params: any[] = []): Promise<number> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('update', query, params, { startedAt })
         }
@@ -267,12 +277,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('update', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('update', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('update', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('update', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -281,7 +291,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeUpdateReturningOneRow(query: string, params: any[] = []): Promise<any> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('updateReturningOneRow', query, params, { startedAt })
         }
@@ -289,12 +299,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('updateReturningOneRow', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('updateReturningOneRow', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('updateReturningOneRow', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('updateReturningOneRow', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -303,7 +313,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeUpdateReturningManyRows(query: string, params: any[] = []): Promise<any[]> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('updateReturningManyRows', query, params, { startedAt })
         }
@@ -311,12 +321,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('updateReturningManyRows', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('updateReturningManyRows', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('updateReturningManyRows', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('updateReturningManyRows', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -325,7 +335,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeUpdateReturningOneColumnOneRow(query: string, params: any[] = []): Promise<any> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('updateReturningOneColumnOneRow', query, params, { startedAt })
         }
@@ -333,12 +343,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('updateReturningOneColumnOneRow', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('updateReturningOneColumnOneRow', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('updateReturningOneColumnOneRow', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('updateReturningOneColumnOneRow', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -347,7 +357,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeUpdateReturningOneColumnManyRows(query: string, params: any[] = []): Promise<any[]> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('updateReturningOneColumnManyRows', query, params, { startedAt })
         }
@@ -355,12 +365,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('updateReturningOneColumnManyRows', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('updateReturningOneColumnManyRows', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('updateReturningOneColumnManyRows', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('updateReturningOneColumnManyRows', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -369,7 +379,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeDelete(query: string, params: any[] = []): Promise<number> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('delete', query, params, { startedAt })
         }
@@ -377,12 +387,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('delete', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('delete', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('delete', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('delete', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -391,7 +401,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeDeleteReturningOneRow(query: string, params: any[] = []): Promise<any> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('deleteReturningOneRow', query, params, { startedAt })
         }
@@ -399,12 +409,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('deleteReturningOneRow', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('deleteReturningOneRow', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('deleteReturningOneRow', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('deleteReturningOneRow', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -413,7 +423,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeDeleteReturningManyRows(query: string, params: any[] = []): Promise<any[]> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('deleteReturningManyRows', query, params, { startedAt })
         }
@@ -421,12 +431,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('deleteReturningManyRows', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('deleteReturningManyRows', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('deleteReturningManyRows', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('deleteReturningManyRows', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -435,7 +445,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeDeleteReturningOneColumnOneRow(query: string, params: any[] = []): Promise<any> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('deleteReturningOneColumnOneRow', query, params, { startedAt })
         }
@@ -443,12 +453,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('deleteReturningOneColumnOneRow', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('deleteReturningOneColumnOneRow', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('deleteReturningOneColumnOneRow', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('deleteReturningOneColumnOneRow', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -457,7 +467,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeDeleteReturningOneColumnManyRows(query: string, params: any[] = []): Promise<any[]> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('deleteReturningOneColumnManyRows', query, params, { startedAt })
         }
@@ -465,12 +475,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('deleteReturningOneColumnManyRows', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('deleteReturningOneColumnManyRows', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('deleteReturningOneColumnManyRows', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('deleteReturningOneColumnManyRows', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -479,7 +489,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeProcedure(query: string, params: any[] = []): Promise<void> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('executeProcedure', query, params, { startedAt })
         }
@@ -487,12 +497,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('executeProcedure', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('executeProcedure', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('executeProcedure', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('executeProcedure', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -501,7 +511,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeFunction(query: string, params: any[] = []): Promise<any> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('executeFunction', query, params, { startedAt })
         }
@@ -509,12 +519,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('executeFunction', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('executeFunction', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('executeFunction', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('executeFunction', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -555,12 +565,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
                     const query: string = ''
                     const params: any[] = opts || []
                     const logger = this.logger
-                    const startedAt = process.hrtime.bigint()
+                    const startedAt = now()
                     if (logger.onQuery) {
                         logger.onQuery('rollback', query, params, { startedAt })
                     }
                     if (logger.onQueryResult) {
-                        logger.onQueryResult('rollback', query, params, undefined, { startedAt, endedAt: process.hrtime.bigint() })
+                        logger.onQueryResult('rollback', query, params, undefined, { startedAt, endedAt: now() })
                     }
                 } catch {
                     // Throw the innermost error
@@ -574,7 +584,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         const query: string = ''
         const params: any[] = opts
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('beginTransaction', query, params, { startedAt })
         }
@@ -582,12 +592,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('beginTransaction', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('beginTransaction', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('beginTransaction', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('beginTransaction', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -598,7 +608,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         const query: string = ''
         const params: any[] = opts
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('commit', query, params, { startedAt })
         }
@@ -606,12 +616,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('commit', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('commit', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('commit', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('commit', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -622,7 +632,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         const query: string = ''
         const params: any[] = opts
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('rollback', query, params, { startedAt })
         }
@@ -630,12 +640,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('rollback', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('rollback', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('rollback', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('rollback', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -644,7 +654,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeDatabaseSchemaModification(query: string, params: any[] = []): Promise<void> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('executeDatabaseSchemaModification', query, params, { startedAt })
         }
@@ -652,12 +662,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('executeDatabaseSchemaModification', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('executeDatabaseSchemaModification', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('executeDatabaseSchemaModification', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('executeDatabaseSchemaModification', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })
@@ -666,7 +676,7 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
     }
     executeConnectionConfiguration(query: string, params: any[] = []): Promise<void> {
         const logger = this.logger
-        const startedAt = process.hrtime.bigint()
+        const startedAt = now()
         if (logger.onQuery) {
             logger.onQuery('executeConnectionConfiguration', query, params, { startedAt })
         }
@@ -674,12 +684,12 @@ export class LoggingQueryRunner<T extends QueryRunner> extends ChainedQueryRunne
         if (logger.onQueryResult || logger.onQueryError) {
             result = result.then(r => {
                 if (logger.onQueryResult) {
-                    logger.onQueryResult('executeConnectionConfiguration', query, params, r, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryResult('executeConnectionConfiguration', query, params, r, { startedAt, endedAt: now() })
                 }
                 return r
             }, e => {
                 if (logger.onQueryError) {
-                    logger.onQueryError('executeConnectionConfiguration', query, params, e, { startedAt, endedAt: process.hrtime.bigint() })
+                    logger.onQueryError('executeConnectionConfiguration', query, params, e, { startedAt, endedAt: now() })
                 }
                 throw e
             })


### PR DESCRIPTION
Since #43, the `LoggingQueryRunner` calls `process.hrtime.bigint()` to get a timestamp for performance measurements. However, this API is not present in non-NodeJS environments (e.g. in the browser).

This PR adds a wrapper function that uses [`performance.now()`](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now) as a fallback if the process module is not available.

Note: In theory we could migrate to using the value returned by `performance.now()` on all platforms. However, this would be a breaking change since some users might have subclassed the logger, because `process.hrtime.bigint()` returns nanoseconds as bigint, while `performance.now()` returns a float in milliseconds. To avoid a breaking change, I multiply the value returned from `performance.now()` by 1_000_000 and wrap it in a bigint, to stick to the same time base. Loss of precision might occur (but browsers may limit timing performance anyways for security reasons).